### PR TITLE
extend data file component

### DIFF
--- a/src/api/dataset/controllers/dataset.js
+++ b/src/api/dataset/controllers/dataset.js
@@ -41,7 +41,7 @@ module.exports = createCoreController('api::dataset.dataset', ({ strapi }) => ({
           fields: ['name', 'slug'],
         },
         data: {
-          fields: ['type']
+          fields: ['name', 'type', 'is_primary_data']
         },
         resources: {
           fields: ['name', 'description', 'type', 'category', 'is_primary_data']

--- a/src/components/data/file.json
+++ b/src/components/data/file.json
@@ -6,6 +6,9 @@
   },
   "options": {},
   "attributes": {
+    "name": {
+      "type": "string"
+    },
     "url": {
       "type": "string"
     },
@@ -19,6 +22,10 @@
         "VitessceConfig"
       ],
       "required": true
+    },
+    "is_primary_data": {
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
# Description

Add `name` and `is_primary_data` to data file component and return in find datasets
so client can handle multiple data files as views

Required to fix https://github.com/haniffalab/cellatlas-io-client/issues/96

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
