### PR TITLE
add is_listed field to study

### DIFF
--- a/config/functions.js
+++ b/config/functions.js
@@ -162,7 +162,16 @@ module.exports = {
         id: { $in: ids },
       };
     }
-    
+
+    // If not providing a study id, return only datasets from studies that are listed
+    if (!ctx.query.filters?.study?.id?.$eq) {
+      ctx.query.filters = {
+        ...ctx.query.filters,
+        study: {
+          is_listed: true },
+      };
+    }
+
     const datasets = await strapi.entityService.findMany('api::dataset.dataset', {
       fields: [ontologyField],
       populate: {

--- a/src/api/dataset/controllers/dataset.js
+++ b/src/api/dataset/controllers/dataset.js
@@ -30,6 +30,15 @@ module.exports = createCoreController('api::dataset.dataset', ({ strapi }) => ({
       };
     }
 
+    // If not providing a study id, return only datasets from studies that are listed
+    if (!ctx.query.filters?.study?.id?.$eq) {
+      ctx.query.filters = {
+        ...ctx.query.filters,
+        study: {
+          is_listed: true },
+      };
+    }
+
     ctx.query = {
       ...ctx.query,
       fields: [

--- a/src/api/study/content-types/study/schema.json
+++ b/src/api/study/content-types/study/schema.json
@@ -86,6 +86,10 @@
       "type": "component",
       "repeatable": true,
       "component": "data.resource"
+    },
+    "is_listed": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/src/api/study/controllers/study.js
+++ b/src/api/study/controllers/study.js
@@ -29,6 +29,11 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
       };
     }
 
+    ctx.query.filters = {
+      ...ctx.query.filters,
+      is_listed: true,
+    };
+
     ctx.query = {
       ...ctx.query,
       fields: [


### PR DESCRIPTION
# Description

Add `is_listed` to study and add filters for datasets, studies and ontologies requests, unless requesting datasets/ontologies of a specific study id

Fixes #52 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
