### PR TITLE
replace study cover_image with cover_dataset

### DIFF
--- a/src/api/dataset/content-types/dataset/schema.json
+++ b/src/api/dataset/content-types/dataset/schema.json
@@ -30,7 +30,7 @@
     },
     "media": {
       "type": "media",
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "allowedTypes": [
         "images",

--- a/src/api/study/content-types/study/schema.json
+++ b/src/api/study/content-types/study/schema.json
@@ -66,17 +66,6 @@
     "subtitle": {
       "type": "text"
     },
-    "cover_image": {
-      "type": "media",
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ]
-    },
     "password": {
       "type": "customField",
       "customField": "plugin::custom-fields.customPassword",
@@ -90,6 +79,11 @@
     "is_listed": {
       "type": "boolean",
       "default": true
+    },
+    "cover_dataset": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::dataset.dataset"
     }
   }
 }

--- a/src/api/study/controllers/study.js
+++ b/src/api/study/controllers/study.js
@@ -78,6 +78,10 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
         },
         resources: {
           fields: ['name', 'description', 'type', 'category' ]
+        },
+        cover_dataset: {
+          fields: [false],
+          populate: ['media'],
         }
       },
     };
@@ -130,7 +134,11 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
           fields: ['name', 'description', 'tissues', 'organisms', 'assays', 'diseases', 'celltypes', 'human_developmental_stages', 'count', 'unit'],
           populate: ['media', 'data', 'resources'],
         },
-        resources: true
+        resources: true,
+        cover_dataset: {
+          fields: [],
+          populate: ['media'],
+        }
       },
     };
 


### PR DESCRIPTION
# Description

remove study media field
replace cover_image with cover_dataset, a relation to a dataset to use its media as study cover in client
change dataset media to single

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
