### PR TITLE
filter study components to those with published relation fields

### DIFF
--- a/src/api/study/controllers/study.js
+++ b/src/api/study/controllers/study.js
@@ -56,6 +56,7 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
         },
         teams: {
           fields: ['is_lead'],
+          filters: { team: { publishedAt: { $notNull: true } } },
           populate: {
             team: {
               fields: ['name', 'website', 'description'],
@@ -65,6 +66,7 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
         },
         contributors: {
           fields: ['is_lead', 'role'],
+          filters: { person: { publishedAt: { $notNull: true } } },
           populate: {
             person: {
               fields: ['first_name', 'last_name'],
@@ -114,6 +116,7 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
         },
         teams: {
           fields: ['is_lead'],
+          filters: { team: { publishedAt: { $notNull: true } } },
           populate: {
             team: {
               fields: ['name', 'website', 'description'],
@@ -123,6 +126,7 @@ module.exports = createCoreController('api::study.study', ({ strapi }) => ({
         },
         contributors: {
           fields: ['is_lead', 'role'],
+          filters: { person: { publishedAt: { $notNull: true } } },
           populate: {
             person: {
               fields: ['first_name', 'last_name'],


### PR DESCRIPTION
# Description

On study find and findOne, filter teams and contributors by having relation field published
e.g. contributor with unpublished person gets filtered out

Fixes #56 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
