### PR TITLE
fix: add disease-genes confidence enums used in updated g2p panels

### DIFF
--- a/src/api/disease-gene/content-types/disease-gene/schema.json
+++ b/src/api/disease-gene/content-types/disease-gene/schema.json
@@ -43,7 +43,9 @@
         "moderate",
         "strong",
         "definitive",
-        "unspecified"
+        "unspecified",
+        "refuted",
+        "disputed"
       ],
       "default": "unspecified"
     },


### PR DESCRIPTION
# Description

add disease-genes confidence enums used in updated g2p panels
add 'refuted' and 'disputed' confidence

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
